### PR TITLE
Security: Removing the hard-coded metrics tag

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -181,11 +181,11 @@ class Main {
 			<script type="text/javascript" >
 				(function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
 					m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
-				(window, document, "script", "https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js", "ym");
+				(window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
 
 				ym(<?php echo esc_js( $yandex_metrika_id ); ?>, "init", <?php echo json_encode( $yandex_metrika_config ); ?>);
 			</script>
-			<noscript><div><img src="https://mc.yandex.ru/watch/5695870" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+			<noscript><div><img src="https://mc.yandex.ru/watch/<?php echo esc_js( $yandex_metrika_id ); ?>" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
 			<!-- /Yandex.Metrika counter -->
 			<?php
 		}


### PR DESCRIPTION
Removing the hard-coded metrics tag and replacing the analytics script URL with the official one